### PR TITLE
CI: bump JDK to zulu@17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.x, 3.3.x]
-        java: [zulu@8]
+        java: [zulu@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        if: matrix.java == 'zulu@8'
+      - name: Setup Java (zulu@17)
+        if: matrix.java == 'zulu@17'
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt
@@ -70,7 +70,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.8]
-        java: [zulu@8]
+        java: [zulu@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -78,12 +78,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        if: matrix.java == 'zulu@8'
+      - name: Setup Java (zulu@17)
+        if: matrix.java == 'zulu@17'
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,8 +8,8 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@8)
-      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, zulu@17)
+      - check-success=Build and Test (ubuntu-latest, 3.3.x, zulu@17)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -16,6 +16,7 @@ inThisBuild(List(
   dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = GitDirtySuffix("")))),
   dynverSonatypeSnapshots             := true,
   versionScheme                       := Some("early-semver"),
+  githubWorkflowJavaVersions          := Seq(JavaSpec.zulu("17")),
   githubWorkflowScalaVersions         := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
   githubWorkflowJobSetup +=
     WorkflowStep.Use(UseRef.Public("actions", "setup-node", "v4"), params = Map("node-version" -> "20")),


### PR DESCRIPTION
The generated workflow pinned `zulu@8`. sbt 2.x requires JDK 17+, so scala-steward's "Update sbt to 2.0.x" PR fails CI on JDK 8.

Adds `githubWorkflowJavaVersions := Seq(JavaSpec.zulu("17"))` in `ci.sbt` and regenerates `.github/workflows/ci.yml` (and `.mergify.yml`, whose check-name conditions embed the Java version) via `githubWorkflowGenerate`. Only the version changes — the distribution stays `zulu`, as it was by sbt-github-actions' default.

Verified locally on JDK 17: `githubWorkflowCheck` passes and `+test` passes on both 2.13.18 and 3.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration checks to run on Java 17.
  - Updated automated dependency merge validation to use Java 17.
  - Standardized the configured Java version across build and test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->